### PR TITLE
[BugFix] 解决重复注册时的bug。

### DIFF
--- a/sekiro-service-demo/src/main/java/com/virjar/sekiro/business/netty/routers/client/NettyClient.java
+++ b/sekiro-service-demo/src/main/java/com/virjar/sekiro/business/netty/routers/client/NettyClient.java
@@ -95,17 +95,6 @@ public class NettyClient extends Context {
     }
 
 
-    void overwrite(NettyClient newClient) {
-        Channel historyChannel = this.channel;
-        this.channel = newClient.channel;
-        if (historyChannel.isActive()) {
-            getLogger().error("duplicate client register old:" + historyChannel
-                    + " new:" + channel);
-            historyChannel.eventLoop().schedule((Runnable) historyChannel::close, 30, TimeUnit.SECONDS);
-        }
-        this.natClientType = newClient.natClientType;
-    }
-
     public void onClientDisconnected() {
         NettySekiroGroup.createOrGet(getSekiroGroup())
                 .safeDo(this::onClientDisconnected0);


### PR DESCRIPTION
[BugFix] 

对于已注册的手机，执行overwrite方法后，nettyClient.doRegister方法未返回old nettyClient，导致invoke调用时使用new nettyClient，使得调用对象不一致，触发异常。解决方案: 调用registerNettyClient0时，删除old nettyClient,添加new nettyClient.

Signed-off-by: zhuguocheng <zhuguocheng@xiaomi.com>